### PR TITLE
Fix issue #9

### DIFF
--- a/co/component.py
+++ b/co/component.py
@@ -2,7 +2,6 @@
 from functools import reduce
 import logging
 
-from Bio import Alphabet
 from Bio.Seq import Seq
 import operator
 from Bio.SeqFeature import FeatureLocation, SeqFeature


### PR DESCRIPTION
Bio.Alphabet has been removed from Biopython and prevents the tool from running with up to date systems